### PR TITLE
Automate CCRS download and add CCRS staging loader

### DIFF
--- a/scripts/download-data.sh
+++ b/scripts/download-data.sh
@@ -135,12 +135,32 @@ echo ""
 # ------------------------------------------------------------
 echo "=== 8. California Crash Data (CCRS) ==="
 echo "   Source: data.ca.gov - https://data.ca.gov/dataset/ccrs"
-echo "  MANUAL: Visit the URL above"
-echo "          Download Crashes, Parties, and InjuredWitnessPassengers CSVs"
-echo "          Save as: $DATA_DIR/ccrs_crashes.csv"
-echo "                   $DATA_DIR/ccrs_parties.csv"
-echo "                   $DATA_DIR/ccrs_victims.csv"
-echo "  Note: Start with one year of data to keep sizes manageable."
+
+# Stable direct resource URLs from data.ca.gov CKAN dataset page.
+# Default to the latest full year snapshot to avoid partial in-progress-year data.
+CCRS_YEAR="${CCRS_YEAR:-2024}"
+case "$CCRS_YEAR" in
+    2024)
+        CCRS_CRASHES_URL="https://data.ca.gov/dataset/80c6a49d-c6b3-40ba-86d8-379c9741b4be/resource/f775df59-b89b-4f82-bd3d-8807fa3a22a0/download/hq1d-p-app52dopendataexport2024crashes.csv"
+        CCRS_PARTIES_URL="https://data.ca.gov/dataset/80c6a49d-c6b3-40ba-86d8-379c9741b4be/resource/93892d36-017b-4a2a-bc0b-f1f385060b96/download/hq1d-p-app52dopendataexport2024parties.csv"
+        CCRS_VICTIMS_URL="https://data.ca.gov/dataset/80c6a49d-c6b3-40ba-86d8-379c9741b4be/resource/a36a0078-d7e1-4244-8337-0a59433c9b84/download/hq1d-p-app52dopendataexport2024injuredwitnesspassengers.csv"
+        ;;
+    *)
+        echo "  WARNING: Unsupported CCRS_YEAR=$CCRS_YEAR for auto-download."
+        echo "           Use CCRS_YEAR=2024 or download manually from data.ca.gov/dataset/ccrs"
+        CCRS_CRASHES_URL=""
+        CCRS_PARTIES_URL=""
+        CCRS_VICTIMS_URL=""
+        ;;
+esac
+
+if [ -n "$CCRS_CRASHES_URL" ]; then
+    download_file "$CCRS_CRASHES_URL" "$DATA_DIR/ccrs_crashes.csv" "CCRS Crashes ($CCRS_YEAR)" || true
+    download_file "$CCRS_PARTIES_URL" "$DATA_DIR/ccrs_parties.csv" "CCRS Parties ($CCRS_YEAR)" || true
+    download_file "$CCRS_VICTIMS_URL" "$DATA_DIR/ccrs_victims.csv" "CCRS Victims ($CCRS_YEAR)" || true
+fi
+
+echo "  If any file failed, manual fallback: https://data.ca.gov/dataset/ccrs"
 echo ""
 
 # ------------------------------------------------------------

--- a/scripts/load-ccrs.sql
+++ b/scripts/load-ccrs.sql
@@ -1,0 +1,256 @@
+-- ============================================================
+-- Load CCRS crash data into crashes / crash_parties / crash_victims
+-- ============================================================
+-- Expected files (downloaded by scripts/download-data.sh):
+--   data/ccrs_crashes.csv
+--   data/ccrs_parties.csv
+--   data/ccrs_victims.csv
+--
+-- Strategy:
+--   1) Load CSVs into all-text staging tables
+--   2) Transform into typed production tables
+--   3) Run validation checks (counts, nulls, FK integrity)
+-- ============================================================
+
+DROP TABLE IF EXISTS ccrs_crashes_staging;
+DROP TABLE IF EXISTS ccrs_parties_staging;
+DROP TABLE IF EXISTS ccrs_victims_staging;
+
+CREATE TABLE ccrs_crashes_staging (
+    case_id TEXT,
+    collision_date TEXT,
+    collision_time TEXT,
+    county TEXT,
+    city TEXT,
+    jurisdiction TEXT,
+    primary_road TEXT,
+    secondary_road TEXT,
+    distance TEXT,
+    direction TEXT,
+    latitude TEXT,
+    longitude TEXT,
+    collision_type TEXT,
+    collision_severity TEXT,
+    num_killed TEXT,
+    num_injured TEXT,
+    party_count TEXT,
+    weather TEXT,
+    road_surface TEXT,
+    road_condition TEXT,
+    lighting TEXT,
+    primary_cause TEXT,
+    pcf_violation TEXT,
+    alcohol_involved TEXT,
+    pedestrian_involved TEXT,
+    bicycle_involved TEXT,
+    motorcycle_involved TEXT,
+    truck_involved TEXT
+);
+
+CREATE TABLE ccrs_parties_staging (
+    party_id TEXT,
+    case_id TEXT,
+    party_number TEXT,
+    party_type TEXT,
+    at_fault TEXT,
+    age TEXT,
+    sex TEXT,
+    sobriety TEXT,
+    direction_of_travel TEXT,
+    vehicle_year TEXT,
+    vehicle_make TEXT,
+    vehicle_type TEXT,
+    movement_preceding TEXT,
+    party_cause TEXT
+);
+
+CREATE TABLE ccrs_victims_staging (
+    victim_id TEXT,
+    case_id TEXT,
+    party_id TEXT,
+    victim_number TEXT,
+    victim_role TEXT,
+    victim_sex TEXT,
+    victim_age TEXT,
+    victim_degree_of_injury TEXT,
+    victim_seating_position TEXT,
+    victim_safety_equipment TEXT
+);
+
+\COPY ccrs_crashes_staging FROM 'data/ccrs_crashes.csv' WITH (FORMAT csv, HEADER true, NULL '');
+\COPY ccrs_parties_staging FROM 'data/ccrs_parties.csv' WITH (FORMAT csv, HEADER true, NULL '');
+\COPY ccrs_victims_staging FROM 'data/ccrs_victims.csv' WITH (FORMAT csv, HEADER true, NULL '');
+
+-- Helper casting function for flexible boolean parsing.
+DROP FUNCTION IF EXISTS parse_bool(TEXT);
+CREATE FUNCTION parse_bool(v TEXT)
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+    SELECT CASE
+        WHEN v IS NULL THEN NULL
+        WHEN lower(trim(v)) IN ('1', 't', 'true', 'y', 'yes') THEN TRUE
+        WHEN lower(trim(v)) IN ('0', 'f', 'false', 'n', 'no') THEN FALSE
+        ELSE NULL
+    END;
+$$;
+
+TRUNCATE TABLE crash_victims, crash_parties, crashes RESTART IDENTITY CASCADE;
+
+INSERT INTO crashes (
+    case_id,
+    collision_date,
+    collision_time,
+    county,
+    city,
+    jurisdiction,
+    primary_road,
+    secondary_road,
+    distance,
+    direction,
+    latitude,
+    longitude,
+    collision_type,
+    collision_severity,
+    num_killed,
+    num_injured,
+    party_count,
+    weather,
+    road_surface,
+    road_condition,
+    lighting,
+    primary_cause,
+    pcf_violation,
+    alcohol_involved,
+    pedestrian_involved,
+    bicycle_involved,
+    motorcycle_involved,
+    truck_involved
+)
+SELECT
+    NULLIF(TRIM(case_id), ''),
+    NULLIF(TRIM(collision_date), '')::DATE,
+    NULLIF(TRIM(collision_time), '')::TIME,
+    NULLIF(TRIM(county), ''),
+    NULLIF(TRIM(city), ''),
+    NULLIF(TRIM(jurisdiction), ''),
+    NULLIF(TRIM(primary_road), ''),
+    NULLIF(TRIM(secondary_road), ''),
+    NULLIF(TRIM(distance), '')::DECIMAL(8, 2),
+    NULLIF(TRIM(direction), ''),
+    NULLIF(TRIM(latitude), '')::DECIMAL(10, 7),
+    NULLIF(TRIM(longitude), '')::DECIMAL(10, 7),
+    NULLIF(TRIM(collision_type), ''),
+    NULLIF(TRIM(collision_severity), ''),
+    NULLIF(TRIM(num_killed), '')::INTEGER,
+    NULLIF(TRIM(num_injured), '')::INTEGER,
+    NULLIF(TRIM(party_count), '')::INTEGER,
+    NULLIF(TRIM(weather), ''),
+    NULLIF(TRIM(road_surface), ''),
+    NULLIF(TRIM(road_condition), ''),
+    NULLIF(TRIM(lighting), ''),
+    NULLIF(TRIM(primary_cause), ''),
+    NULLIF(TRIM(pcf_violation), ''),
+    parse_bool(alcohol_involved),
+    parse_bool(pedestrian_involved),
+    parse_bool(bicycle_involved),
+    parse_bool(motorcycle_involved),
+    parse_bool(truck_involved)
+FROM ccrs_crashes_staging
+WHERE NULLIF(TRIM(case_id), '') IS NOT NULL;
+
+INSERT INTO crash_parties (
+    party_id,
+    case_id,
+    party_number,
+    party_type,
+    at_fault,
+    age,
+    sex,
+    sobriety,
+    direction_of_travel,
+    vehicle_year,
+    vehicle_make,
+    vehicle_type,
+    movement_preceding,
+    party_cause
+)
+SELECT
+    NULLIF(TRIM(party_id), ''),
+    NULLIF(TRIM(case_id), ''),
+    NULLIF(TRIM(party_number), '')::INTEGER,
+    NULLIF(TRIM(party_type), ''),
+    parse_bool(at_fault),
+    NULLIF(TRIM(age), '')::INTEGER,
+    NULLIF(TRIM(sex), ''),
+    NULLIF(TRIM(sobriety), ''),
+    NULLIF(TRIM(direction_of_travel), ''),
+    NULLIF(TRIM(vehicle_year), '')::INTEGER,
+    NULLIF(TRIM(vehicle_make), ''),
+    NULLIF(TRIM(vehicle_type), ''),
+    NULLIF(TRIM(movement_preceding), ''),
+    NULLIF(TRIM(party_cause), '')
+FROM ccrs_parties_staging
+WHERE NULLIF(TRIM(party_id), '') IS NOT NULL
+  AND NULLIF(TRIM(case_id), '') IS NOT NULL;
+
+INSERT INTO crash_victims (
+    victim_id,
+    case_id,
+    party_id,
+    victim_number,
+    victim_role,
+    victim_sex,
+    victim_age,
+    victim_degree_of_injury,
+    victim_seating_position,
+    victim_safety_equipment
+)
+SELECT
+    NULLIF(TRIM(victim_id), ''),
+    NULLIF(TRIM(case_id), ''),
+    NULLIF(TRIM(party_id), ''),
+    NULLIF(TRIM(victim_number), '')::INTEGER,
+    NULLIF(TRIM(victim_role), ''),
+    NULLIF(TRIM(victim_sex), ''),
+    NULLIF(TRIM(victim_age), '')::INTEGER,
+    NULLIF(TRIM(victim_degree_of_injury), ''),
+    NULLIF(TRIM(victim_seating_position), ''),
+    NULLIF(TRIM(victim_safety_equipment), '')
+FROM ccrs_victims_staging
+WHERE NULLIF(TRIM(victim_id), '') IS NOT NULL
+  AND NULLIF(TRIM(case_id), '') IS NOT NULL;
+
+-- Validation checks
+SELECT 'crashes_count' AS check_name, COUNT(*)::BIGINT AS value FROM crashes
+UNION ALL
+SELECT 'crash_parties_count', COUNT(*)::BIGINT FROM crash_parties
+UNION ALL
+SELECT 'crash_victims_count', COUNT(*)::BIGINT FROM crash_victims
+UNION ALL
+SELECT 'crashes_null_case_id', COUNT(*)::BIGINT FROM crashes WHERE case_id IS NULL
+UNION ALL
+SELECT 'crash_parties_null_party_id', COUNT(*)::BIGINT FROM crash_parties WHERE party_id IS NULL
+UNION ALL
+SELECT 'crash_victims_null_victim_id', COUNT(*)::BIGINT FROM crash_victims WHERE victim_id IS NULL
+UNION ALL
+SELECT 'orphan_parties_missing_crash', COUNT(*)::BIGINT
+FROM crash_parties p
+LEFT JOIN crashes c ON c.case_id = p.case_id
+WHERE c.case_id IS NULL
+UNION ALL
+SELECT 'orphan_victims_missing_crash', COUNT(*)::BIGINT
+FROM crash_victims v
+LEFT JOIN crashes c ON c.case_id = v.case_id
+WHERE c.case_id IS NULL
+UNION ALL
+SELECT 'orphan_victims_missing_party', COUNT(*)::BIGINT
+FROM crash_victims v
+LEFT JOIN crash_parties p ON p.party_id = v.party_id
+WHERE p.party_id IS NULL;
+
+DROP TABLE ccrs_crashes_staging;
+DROP TABLE ccrs_parties_staging;
+DROP TABLE ccrs_victims_staging;
+DROP FUNCTION parse_bool(TEXT);

--- a/scripts/load-data.sh
+++ b/scripts/load-data.sh
@@ -77,6 +77,32 @@ else
     echo "  Run ./scripts/download-data.sh first"
 fi
 
+# ------------------------------------------------------------
+# Load CCRS crash data
+# ------------------------------------------------------------
+CCRS_CRASHES_FILE="$DATA_DIR/ccrs_crashes.csv"
+CCRS_PARTIES_FILE="$DATA_DIR/ccrs_parties.csv"
+CCRS_VICTIMS_FILE="$DATA_DIR/ccrs_victims.csv"
+if [ -f "$CCRS_CRASHES_FILE" ] && [ -f "$CCRS_PARTIES_FILE" ] && [ -f "$CCRS_VICTIMS_FILE" ]; then
+    echo "Loading CCRS crash data (staging + transform + validation)..."
+    cd "$REPO_DIR"
+    run_sql -f "$REPO_DIR/scripts/load-ccrs.sql"
+    if [ $? -eq 0 ]; then
+        CRASH_COUNT=$(run_sql -t -c "SELECT COUNT(*) FROM crashes;" | tr -d ' ')
+        PARTY_COUNT=$(run_sql -t -c "SELECT COUNT(*) FROM crash_parties;" | tr -d ' ')
+        VICTIM_COUNT=$(run_sql -t -c "SELECT COUNT(*) FROM crash_victims;" | tr -d ' ')
+        echo "  Loaded crashes=$CRASH_COUNT parties=$PARTY_COUNT victims=$VICTIM_COUNT"
+    else
+        echo "  CCRS load failed. Check scripts/load-ccrs.sql for details."
+    fi
+else
+    echo "Skipping CCRS data (missing one or more files):"
+    echo "  $CCRS_CRASHES_FILE"
+    echo "  $CCRS_PARTIES_FILE"
+    echo "  $CCRS_VICTIMS_FILE"
+    echo "  Run ./scripts/download-data.sh first"
+fi
+
 echo ""
 echo "=== Data loading complete ==="
 echo ""


### PR DESCRIPTION
### Motivation
- Remove the manual CCRS download step and provide a stable automated way to fetch the California Crash Reporting System data so Practice Project 03 and multi-table JOIN exercises can run against real crash data. 
- Prefer pinned annual snapshot URLs to avoid pulling partial in-progress-year exports.

### Description
- Added automated CCRS resource URLs and `CCRS_YEAR` handling to `scripts/download-data.sh` and call `download_file` for `ccrs_crashes.csv`, `ccrs_parties.csv`, and `ccrs_victims.csv` with a manual fallback message. 
- Added `scripts/load-ccrs.sql` which implements a staging-based loader that `\COPY`s CSVs into all-text staging tables, casts/transforms rows into `crashes`, `crash_parties`, and `crash_victims`, provides a `parse_bool` helper, truncates/reloads target tables, and runs validation queries (counts, null key checks, and orphan FK checks). 
- Updated `scripts/load-data.sh` to detect the three CCRS CSVs and run `scripts/load-ccrs.sql` when present, then print loaded row counts or a helpful skip message. 

### Testing
- Ran `bash -n scripts/download-data.sh` to validate the updated downloader script and it succeeded. 
- Ran `bash -n scripts/load-data.sh` to validate the loader orchestration changes and it succeeded. 
- Attempted `curl -I -L` against the `data.ca.gov` CCRS resource URLs from this environment and received `403` responses due to network/path restrictions, so end-to-end download could not be validated here; full execution requires network access and local CSV files plus a reachable PostgreSQL server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5d749b53c8324b4009caa0d75e383)