### PR TITLE
Automate AADT and truck traffic download/load pipeline

### DIFF
--- a/scripts/download-data.sh
+++ b/scripts/download-data.sh
@@ -33,6 +33,7 @@ download_file() {
         echo "  Saved to: $(basename "$dest")"
         return 0
     else
+        rm -f "$dest"
         echo "  WARNING: Download failed. See manual instructions below."
         return 1
     fi

--- a/scripts/download-data.sh
+++ b/scripts/download-data.sh
@@ -81,10 +81,13 @@ echo ""
 # Annual Average Daily Traffic across the highway system
 # ------------------------------------------------------------
 echo "=== 4. Traffic Volumes AADT ==="
-echo "   Source: data.ca.gov"
-echo "  MANUAL: Visit https://data.ca.gov/dataset/annual-average-daily-traffic"
-echo "          Click 'Download' on the CSV file"
-echo "          Save as: $DATA_DIR/traffic_aadt.csv"
+echo "   Source: data.ca.gov / Caltrans GIS"
+AADT_URL="https://gis.data.ca.gov/api/download/v1/items/d8833219913c44358f2a9a71bda57f76/csv?layers=0"
+download_file "$AADT_URL" "$DATA_DIR/traffic_aadt.csv" "Traffic Volumes AADT" || {
+    echo "  Manual: Visit https://lab.data.ca.gov/dataset/annual-average-daily-traffic"
+    echo "          Click Download > CSV"
+    echo "          Save as: $DATA_DIR/traffic_aadt.csv"
+}
 echo ""
 
 # ------------------------------------------------------------
@@ -93,10 +96,13 @@ echo ""
 # Relevant for pavement design (EAL data)
 # ------------------------------------------------------------
 echo "=== 5. Truck Volumes AADT ==="
-echo "   Source: data.ca.gov"
-echo "  MANUAL: Visit https://gisdata-caltrans.opendata.arcgis.com/datasets/c079bdd6a2c54aec84b6b2f7d6570f6d_0/about"
-echo "          Download as CSV"
-echo "          Save as: $DATA_DIR/truck_aadt.csv"
+echo "   Source: data.ca.gov / Caltrans GIS"
+TRUCK_AADT_URL="https://gis.data.ca.gov/api/download/v1/items/c079bdd6a2c54aec84b6b2f7d6570f6d/csv?layers=0"
+download_file "$TRUCK_AADT_URL" "$DATA_DIR/truck_aadt.csv" "Truck Volumes AADT" || {
+    echo "  Manual: Visit https://lab.data.ca.gov/dataset/truck-average-daily-traffic"
+    echo "          Click Download > CSV"
+    echo "          Save as: $DATA_DIR/truck_aadt.csv"
+}
 echo ""
 
 # ------------------------------------------------------------

--- a/scripts/load-data.sh
+++ b/scripts/load-data.sh
@@ -86,8 +86,7 @@ TRUCK_FILE="$DATA_DIR/truck_aadt.csv"
 if [ -f "$TRAFFIC_FILE" ] && [ -f "$TRUCK_FILE" ]; then
     echo "Loading AADT + truck traffic data (staging + transform + upsert)..."
     cd "$REPO_DIR"
-    run_sql -f "$REPO_DIR/scripts/load-traffic.sql"
-    if [ $? -eq 0 ]; then
+    if run_sql -v ON_ERROR_STOP=1 -f "$REPO_DIR/scripts/load-traffic.sql"; then
         TRAFFIC_COUNT=$(run_sql -t -c "SELECT COUNT(*) FROM traffic_counts;" | tr -d ' ')
         TRUCK_COUNT=$(run_sql -t -c "SELECT COUNT(*) FROM truck_traffic;" | tr -d ' ')
         echo "  Loaded traffic_counts=$TRAFFIC_COUNT truck_traffic=$TRUCK_COUNT"

--- a/scripts/load-data.sh
+++ b/scripts/load-data.sh
@@ -77,6 +77,30 @@ else
     echo "  Run ./scripts/download-data.sh first"
 fi
 
+
+# ------------------------------------------------------------
+# Load AADT traffic data
+# ------------------------------------------------------------
+TRAFFIC_FILE="$DATA_DIR/traffic_aadt.csv"
+TRUCK_FILE="$DATA_DIR/truck_aadt.csv"
+if [ -f "$TRAFFIC_FILE" ] && [ -f "$TRUCK_FILE" ]; then
+    echo "Loading AADT + truck traffic data (staging + transform + upsert)..."
+    cd "$REPO_DIR"
+    run_sql -f "$REPO_DIR/scripts/load-traffic.sql"
+    if [ $? -eq 0 ]; then
+        TRAFFIC_COUNT=$(run_sql -t -c "SELECT COUNT(*) FROM traffic_counts;" | tr -d ' ')
+        TRUCK_COUNT=$(run_sql -t -c "SELECT COUNT(*) FROM truck_traffic;" | tr -d ' ')
+        echo "  Loaded traffic_counts=$TRAFFIC_COUNT truck_traffic=$TRUCK_COUNT"
+    else
+        echo "  Traffic load failed. Check scripts/load-traffic.sql for details."
+    fi
+else
+    echo "Skipping traffic data (missing one or more files):"
+    echo "  $TRAFFIC_FILE"
+    echo "  $TRUCK_FILE"
+    echo "  Run ./scripts/download-data.sh first"
+fi
+
 # ------------------------------------------------------------
 # Load CCRS crash data
 # ------------------------------------------------------------

--- a/scripts/load-traffic.sql
+++ b/scripts/load-traffic.sql
@@ -14,7 +14,7 @@
 DROP TABLE IF EXISTS traffic_counts_staging;
 DROP TABLE IF EXISTS truck_traffic_staging;
 
-CREATE TABLE traffic_counts_staging (
+CREATE TEMP TABLE traffic_counts_staging (
     objectid TEXT,
     district TEXT,
     rte TEXT,
@@ -32,7 +32,7 @@ CREATE TABLE traffic_counts_staging (
     ahead_aadt TEXT
 );
 
-CREATE TABLE truck_traffic_staging (
+CREATE TEMP TABLE truck_traffic_staging (
     objectid TEXT,
     rte TEXT,
     rte_sfx TEXT,
@@ -62,9 +62,9 @@ CREATE TABLE truck_traffic_staging (
 \COPY traffic_counts_staging FROM 'data/traffic_aadt.csv' WITH (FORMAT csv, HEADER true, NULL '');
 \COPY truck_traffic_staging FROM 'data/truck_aadt.csv' WITH (FORMAT csv, HEADER true, NULL '');
 
--- Flexible numeric parsing helpers.
-DROP FUNCTION IF EXISTS parse_int(TEXT);
-CREATE FUNCTION parse_int(v TEXT)
+-- Flexible numeric parsing helpers (created in pg_temp so they auto-drop at session end).
+DROP FUNCTION IF EXISTS pg_temp.parse_int(TEXT);
+CREATE FUNCTION pg_temp.parse_int(v TEXT)
 RETURNS INTEGER
 LANGUAGE SQL
 IMMUTABLE
@@ -77,8 +77,8 @@ AS $$
     END;
 $$;
 
-DROP FUNCTION IF EXISTS parse_dec(TEXT);
-CREATE FUNCTION parse_dec(v TEXT)
+DROP FUNCTION IF EXISTS pg_temp.parse_dec(TEXT);
+CREATE FUNCTION pg_temp.parse_dec(v TEXT)
 RETURNS DECIMAL
 LANGUAGE SQL
 IMMUTABLE
@@ -93,7 +93,11 @@ $$;
 
 -- Traffic AADT source currently publishes one snapshot year.
 -- Allow override from shell: TRAFFIC_COUNT_YEAR=2025 ./scripts/load-data.sh
-\set traffic_count_year `bash -lc 'echo ${TRAFFIC_COUNT_YEAR:-2025}'`
+\getenv traffic_count_year TRAFFIC_COUNT_YEAR
+\if :{?traffic_count_year}
+\else
+\set traffic_count_year 2025
+\endif
 
 INSERT INTO traffic_counts (
     station_id,
@@ -118,12 +122,10 @@ SELECT
                 '|',
                 NULLIF(TRIM(rte), ''),
                 NULLIF(TRIM(rte_sfx), ''),
-                NULLIF(TRIM(district), ''),
                 NULLIF(TRIM(cnty), ''),
                 NULLIF(TRIM(pm_pfx), ''),
                 NULLIF(TRIM(pm), ''),
-                NULLIF(TRIM(pm_sfx), ''),
-                NULLIF(TRIM(description), '')
+                NULLIF(TRIM(pm_sfx), '')
             )
         ),
         20
@@ -132,10 +134,10 @@ SELECT
     NULLIF(TRIM(district), ''),
     NULLIF(TRIM(cnty), ''),
     NULLIF(TRIM(rte), ''),
-    parse_dec(pm)::DECIMAL(8, 3),
+    pg_temp.parse_dec(pm)::DECIMAL(8, 3),
     NULLIF(TRIM(description), ''),
-    parse_int(ahead_aadt),
-    parse_int(ahead_peak_madt),
+    pg_temp.parse_int(ahead_aadt),
+    pg_temp.parse_int(ahead_peak_madt),
     NULLIF(TRIM(ahead_peak_hour), ''),
     NULL,
     NULL,
@@ -187,38 +189,36 @@ SELECT
                 '|',
                 NULLIF(TRIM(rte), ''),
                 NULLIF(TRIM(rte_sfx), ''),
-                NULLIF(TRIM(dist), ''),
                 NULLIF(TRIM(cnty), ''),
                 NULLIF(TRIM(pm_pfx), ''),
                 NULLIF(TRIM(postmile), ''),
-                NULLIF(TRIM(pm_sfx), ''),
-                NULLIF(TRIM(leg), '')
+                NULLIF(TRIM(pm_sfx), '')
             )
         ),
         20
     ) AS station_id,
-    parse_int(est_year) AS count_year,
+    pg_temp.parse_int(est_year) AS count_year,
     NULLIF(TRIM(dist), ''),
     NULLIF(TRIM(cnty), ''),
     NULLIF(TRIM(rte), ''),
-    parse_dec(postmile)::DECIMAL(8, 3),
+    pg_temp.parse_dec(postmile)::DECIMAL(8, 3),
     NULLIF(TRIM(description), ''),
-    parse_int(vehicle_aadt_total),
-    parse_int(tot_trk_aadt),
-    parse_dec(trk_percent_tot)::DECIMAL(5, 2),
-    parse_int(trk_2_axle),
-    parse_dec(trk_2_axle_pct)::DECIMAL(5, 2),
-    parse_int(trk_3_axle),
-    parse_dec(trk_3_axle_pct)::DECIMAL(5, 2),
-    parse_int(trk_4_axle),
-    parse_dec(trk_4_axle_pct)::DECIMAL(5, 2),
-    parse_int(trk_5_axle),
-    parse_dec(trk_5_axle_pct)::DECIMAL(5, 2),
-    parse_dec(eal)::DECIMAL(15, 2),
+    pg_temp.parse_int(vehicle_aadt_total),
+    pg_temp.parse_int(tot_trk_aadt),
+    pg_temp.parse_dec(trk_percent_tot)::DECIMAL(5, 2),
+    pg_temp.parse_int(trk_2_axle),
+    pg_temp.parse_dec(trk_2_axle_pct)::DECIMAL(5, 2),
+    pg_temp.parse_int(trk_3_axle),
+    pg_temp.parse_dec(trk_3_axle_pct)::DECIMAL(5, 2),
+    pg_temp.parse_int(trk_4_axle),
+    pg_temp.parse_dec(trk_4_axle_pct)::DECIMAL(5, 2),
+    pg_temp.parse_int(trk_5_axle),
+    pg_temp.parse_dec(trk_5_axle_pct)::DECIMAL(5, 2),
+    pg_temp.parse_dec(eal)::DECIMAL(15, 2),
     NULL,
     NULL
 FROM truck_traffic_staging
-WHERE parse_int(est_year) IS NOT NULL
+WHERE pg_temp.parse_int(est_year) IS NOT NULL
 ON CONFLICT (station_id, count_year) DO UPDATE SET
     district = EXCLUDED.district,
     county = EXCLUDED.county,
@@ -246,5 +246,5 @@ SELECT 'truck_traffic', COUNT(*)::BIGINT FROM truck_traffic;
 
 DROP TABLE IF EXISTS traffic_counts_staging;
 DROP TABLE IF EXISTS truck_traffic_staging;
-DROP FUNCTION IF EXISTS parse_int(TEXT);
-DROP FUNCTION IF EXISTS parse_dec(TEXT);
+DROP FUNCTION IF EXISTS pg_temp.parse_int(TEXT);
+DROP FUNCTION IF EXISTS pg_temp.parse_dec(TEXT);

--- a/scripts/load-traffic.sql
+++ b/scripts/load-traffic.sql
@@ -93,7 +93,13 @@ $$;
 
 -- Traffic AADT source currently publishes one snapshot year.
 -- Allow override from shell: TRAFFIC_COUNT_YEAR=2025 ./scripts/load-data.sh
-\set traffic_count_year `bash -lc 'echo ${TRAFFIC_COUNT_YEAR:-2025}'`
+\getenv traffic_count_year TRAFFIC_COUNT_YEAR
+\if :{?traffic_count_year}
+-- traffic_count_year was set from the environment
+\else
+-- TRAFFIC_COUNT_YEAR not set; use default
+\set traffic_count_year 2025
+\endif
 
 INSERT INTO traffic_counts (
     station_id,

--- a/scripts/load-traffic.sql
+++ b/scripts/load-traffic.sql
@@ -1,0 +1,250 @@
+-- ============================================================
+-- Load Caltrans AADT + truck AADT data
+-- ============================================================
+-- Expected files (downloaded by scripts/download-data.sh):
+--   data/traffic_aadt.csv
+--   data/truck_aadt.csv
+--
+-- Strategy:
+--   1) Load CSVs into all-text staging tables
+--   2) Transform/cast into typed production tables
+--   3) Upsert on (station_id, count_year)
+-- ============================================================
+
+DROP TABLE IF EXISTS traffic_counts_staging;
+DROP TABLE IF EXISTS truck_traffic_staging;
+
+CREATE TABLE traffic_counts_staging (
+    objectid TEXT,
+    district TEXT,
+    rte TEXT,
+    rte_sfx TEXT,
+    cnty TEXT,
+    pm_pfx TEXT,
+    pm TEXT,
+    pm_sfx TEXT,
+    description TEXT,
+    back_peak_hour TEXT,
+    back_peak_madt TEXT,
+    back_aadt TEXT,
+    ahead_peak_hour TEXT,
+    ahead_peak_madt TEXT,
+    ahead_aadt TEXT
+);
+
+CREATE TABLE truck_traffic_staging (
+    objectid TEXT,
+    rte TEXT,
+    rte_sfx TEXT,
+    dist TEXT,
+    cnty TEXT,
+    pm_pfx TEXT,
+    postmile TEXT,
+    pm_sfx TEXT,
+    leg TEXT,
+    description TEXT,
+    vehicle_aadt_total TEXT,
+    tot_trk_aadt TEXT,
+    trk_percent_tot TEXT,
+    trk_2_axle TEXT,
+    trk_2_axle_pct TEXT,
+    trk_3_axle TEXT,
+    trk_3_axle_pct TEXT,
+    trk_4_axle TEXT,
+    trk_4_axle_pct TEXT,
+    trk_5_axle TEXT,
+    trk_5_axle_pct TEXT,
+    eal TEXT,
+    est_year TEXT,
+    est_code TEXT
+);
+
+\COPY traffic_counts_staging FROM 'data/traffic_aadt.csv' WITH (FORMAT csv, HEADER true, NULL '');
+\COPY truck_traffic_staging FROM 'data/truck_aadt.csv' WITH (FORMAT csv, HEADER true, NULL '');
+
+-- Flexible numeric parsing helpers.
+DROP FUNCTION IF EXISTS parse_int(TEXT);
+CREATE FUNCTION parse_int(v TEXT)
+RETURNS INTEGER
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+    SELECT CASE
+        WHEN v IS NULL THEN NULL
+        WHEN trim(v) = '' THEN NULL
+        WHEN regexp_replace(v, '[^0-9\-]', '', 'g') = '' THEN NULL
+        ELSE regexp_replace(v, '[^0-9\-]', '', 'g')::INTEGER
+    END;
+$$;
+
+DROP FUNCTION IF EXISTS parse_dec(TEXT);
+CREATE FUNCTION parse_dec(v TEXT)
+RETURNS DECIMAL
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+    SELECT CASE
+        WHEN v IS NULL THEN NULL
+        WHEN trim(v) = '' THEN NULL
+        WHEN regexp_replace(v, '[^0-9\.\-]', '', 'g') IN ('', '-', '.', '-.') THEN NULL
+        ELSE regexp_replace(v, '[^0-9\.\-]', '', 'g')::DECIMAL
+    END;
+$$;
+
+-- Traffic AADT source currently publishes one snapshot year.
+-- Allow override from shell: TRAFFIC_COUNT_YEAR=2025 ./scripts/load-data.sh
+\set traffic_count_year `bash -lc 'echo ${TRAFFIC_COUNT_YEAR:-2025}'`
+
+INSERT INTO traffic_counts (
+    station_id,
+    count_year,
+    district,
+    county,
+    route,
+    post_mile,
+    description,
+    aadt_total,
+    aadt_peak_hour,
+    peak_hour,
+    aadt_truck,
+    truck_pct,
+    latitude,
+    longitude
+)
+SELECT
+    LEFT(
+        md5(
+            concat_ws(
+                '|',
+                NULLIF(TRIM(rte), ''),
+                NULLIF(TRIM(rte_sfx), ''),
+                NULLIF(TRIM(district), ''),
+                NULLIF(TRIM(cnty), ''),
+                NULLIF(TRIM(pm_pfx), ''),
+                NULLIF(TRIM(pm), ''),
+                NULLIF(TRIM(pm_sfx), ''),
+                NULLIF(TRIM(description), '')
+            )
+        ),
+        20
+    ) AS station_id,
+    :'traffic_count_year'::INTEGER AS count_year,
+    NULLIF(TRIM(district), ''),
+    NULLIF(TRIM(cnty), ''),
+    NULLIF(TRIM(rte), ''),
+    parse_dec(pm)::DECIMAL(8, 3),
+    NULLIF(TRIM(description), ''),
+    parse_int(ahead_aadt),
+    parse_int(ahead_peak_madt),
+    NULLIF(TRIM(ahead_peak_hour), ''),
+    NULL,
+    NULL,
+    NULL,
+    NULL
+FROM traffic_counts_staging
+WHERE COALESCE(NULLIF(TRIM(rte), ''), NULLIF(TRIM(description), '')) IS NOT NULL
+ON CONFLICT (station_id, count_year) DO UPDATE SET
+    district = EXCLUDED.district,
+    county = EXCLUDED.county,
+    route = EXCLUDED.route,
+    post_mile = EXCLUDED.post_mile,
+    description = EXCLUDED.description,
+    aadt_total = EXCLUDED.aadt_total,
+    aadt_peak_hour = EXCLUDED.aadt_peak_hour,
+    peak_hour = EXCLUDED.peak_hour,
+    aadt_truck = EXCLUDED.aadt_truck,
+    truck_pct = EXCLUDED.truck_pct,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude;
+
+INSERT INTO truck_traffic (
+    station_id,
+    count_year,
+    district,
+    county,
+    route,
+    post_mile,
+    description,
+    vehicle_aadt_total,
+    truck_aadt_total,
+    truck_pct_total,
+    truck_2_axle,
+    truck_2_axle_pct,
+    truck_3_axle,
+    truck_3_axle_pct,
+    truck_4_axle,
+    truck_4_axle_pct,
+    truck_5_axle,
+    truck_5_axle_pct,
+    eal,
+    latitude,
+    longitude
+)
+SELECT
+    LEFT(
+        md5(
+            concat_ws(
+                '|',
+                NULLIF(TRIM(rte), ''),
+                NULLIF(TRIM(rte_sfx), ''),
+                NULLIF(TRIM(dist), ''),
+                NULLIF(TRIM(cnty), ''),
+                NULLIF(TRIM(pm_pfx), ''),
+                NULLIF(TRIM(postmile), ''),
+                NULLIF(TRIM(pm_sfx), ''),
+                NULLIF(TRIM(leg), '')
+            )
+        ),
+        20
+    ) AS station_id,
+    parse_int(est_year) AS count_year,
+    NULLIF(TRIM(dist), ''),
+    NULLIF(TRIM(cnty), ''),
+    NULLIF(TRIM(rte), ''),
+    parse_dec(postmile)::DECIMAL(8, 3),
+    NULLIF(TRIM(description), ''),
+    parse_int(vehicle_aadt_total),
+    parse_int(tot_trk_aadt),
+    parse_dec(trk_percent_tot)::DECIMAL(5, 2),
+    parse_int(trk_2_axle),
+    parse_dec(trk_2_axle_pct)::DECIMAL(5, 2),
+    parse_int(trk_3_axle),
+    parse_dec(trk_3_axle_pct)::DECIMAL(5, 2),
+    parse_int(trk_4_axle),
+    parse_dec(trk_4_axle_pct)::DECIMAL(5, 2),
+    parse_int(trk_5_axle),
+    parse_dec(trk_5_axle_pct)::DECIMAL(5, 2),
+    parse_dec(eal)::DECIMAL(15, 2),
+    NULL,
+    NULL
+FROM truck_traffic_staging
+WHERE parse_int(est_year) IS NOT NULL
+ON CONFLICT (station_id, count_year) DO UPDATE SET
+    district = EXCLUDED.district,
+    county = EXCLUDED.county,
+    route = EXCLUDED.route,
+    post_mile = EXCLUDED.post_mile,
+    description = EXCLUDED.description,
+    vehicle_aadt_total = EXCLUDED.vehicle_aadt_total,
+    truck_aadt_total = EXCLUDED.truck_aadt_total,
+    truck_pct_total = EXCLUDED.truck_pct_total,
+    truck_2_axle = EXCLUDED.truck_2_axle,
+    truck_2_axle_pct = EXCLUDED.truck_2_axle_pct,
+    truck_3_axle = EXCLUDED.truck_3_axle,
+    truck_3_axle_pct = EXCLUDED.truck_3_axle_pct,
+    truck_4_axle = EXCLUDED.truck_4_axle,
+    truck_4_axle_pct = EXCLUDED.truck_4_axle_pct,
+    truck_5_axle = EXCLUDED.truck_5_axle,
+    truck_5_axle_pct = EXCLUDED.truck_5_axle_pct,
+    eal = EXCLUDED.eal,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude;
+
+SELECT 'traffic_counts' AS table_name, COUNT(*)::BIGINT AS row_count FROM traffic_counts
+UNION ALL
+SELECT 'truck_traffic', COUNT(*)::BIGINT FROM truck_traffic;
+
+DROP TABLE traffic_counts_staging;
+DROP TABLE truck_traffic_staging;
+DROP FUNCTION parse_int(TEXT);
+DROP FUNCTION parse_dec(TEXT);

--- a/scripts/load-traffic.sql
+++ b/scripts/load-traffic.sql
@@ -244,7 +244,7 @@ SELECT 'traffic_counts' AS table_name, COUNT(*)::BIGINT AS row_count FROM traffi
 UNION ALL
 SELECT 'truck_traffic', COUNT(*)::BIGINT FROM truck_traffic;
 
-DROP TABLE traffic_counts_staging;
-DROP TABLE truck_traffic_staging;
-DROP FUNCTION parse_int(TEXT);
-DROP FUNCTION parse_dec(TEXT);
+DROP TABLE IF EXISTS traffic_counts_staging;
+DROP TABLE IF EXISTS truck_traffic_staging;
+DROP FUNCTION IF EXISTS parse_int(TEXT);
+DROP FUNCTION IF EXISTS parse_dec(TEXT);


### PR DESCRIPTION
### Motivation

- Eliminate manual CSV download steps for AADT and truck AADT and make traffic data part of the automated dataset pipeline. 
- Provide a robust staging → transform → upsert load pattern so repeated loads are idempotent and honor the composite primary key `(station_id, count_year)`. 
- Preserve truck axle-class and EAL data for pavement-analysis exercises and practice projects.

### Description

- Added direct Caltrans GIS download URLs and safe fallback/manual instructions to `scripts/download-data.sh` for `traffic_aadt.csv` and `truck_aadt.csv`. 
- Added `scripts/load-traffic.sql`, which creates all-text staging tables, parsing helpers (`parse_int`, `parse_dec`), deterministic `station_id` generation (MD5 of location fields), and `INSERT ... ON CONFLICT (station_id, count_year) DO UPDATE` upserts for both `traffic_counts` and `truck_traffic`.
- Made the traffic AADT year configurable via `TRAFFIC_COUNT_YEAR` with a default (used in `load-traffic.sql`) to handle snapshot datasets that lack an explicit year column. 
- Wired the new loader into `scripts/load-data.sh` so the traffic loader runs when both `data/traffic_aadt.csv` and `data/truck_aadt.csv` are present and prints post-load row counts.

### Testing

- Ran shell syntax checks: `bash -n scripts/download-data.sh` succeeded. 
- Ran shell syntax checks: `bash -n scripts/load-data.sh` succeeded. 
- Attempted to verify direct ArcGIS CSV downloads with `curl` against the Caltrans/GIS endpoints, but the environment returned HTTP 403 so end-to-end download+load could not be validated here. 
- The SQL loader was created and basic static checks (script presence and syntax via `psql` invocation paths in `load-data.sh`) were exercised, but a live `psql` load was not performed in this environment due to the download restriction and no running test database.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5e11ae98c83248672c54056c4f294)