### PR TITLE
Add PostGIS bootstrap and spatial SQL exercise module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A hands-on SQL practice environment using real California transportation data. U
 - **PostgreSQL server** accessible on your network
 - **JetBrains DataGrip** (or any SQL client)
 - **psql CLI** for running setup scripts (`brew install libpq` on macOS, then add to PATH)
+- **PostGIS extension available on your server** (required for the optional spatial module in `exercises/09-spatial-postgis/`)
 
 ## Quick Start
 
@@ -16,6 +17,7 @@ cp .env.example .env
 # Edit .env with your server connection details
 
 # 2. Create the database and tables
+#    (also attempts to enable PostGIS if available)
 ./scripts/setup-database.sh
 
 # 3. Download public datasets
@@ -123,6 +125,7 @@ Work through the exercises in order. Each file has examples to study, then quest
 | 06  | Window Functions, running totals, percentiles | `exercises/06-window-functions/` | Intermediate/Advanced |
 | 07  | CTEs and multi-step analysis | `exercises/07-ctes/`    | Intermediate/Advanced |
 | 08  | Practice Projects   | `exercises/08-practice-projects/` | All levels  |
+| 09  | Spatial analysis with PostGIS | `exercises/09-spatial-postgis/` | Advanced |
 
 ### Recently Added Exercises
 
@@ -135,6 +138,7 @@ Work through the exercises in order. Each file has examples to study, then quest
 - `exercises/05-subqueries/02-exists-and-not-exists.sql`
 - `exercises/06-window-functions/02-running-stats-and-percentiles.sql`
 - `exercises/07-ctes/02-multi-step-analysis.sql`
+- `exercises/09-spatial-postgis/01-postgis-spatial-analysis.sql`
 
 ### Expanded Practice Projects
 
@@ -177,6 +181,7 @@ Work through the exercises in order. Each file has examples to study, then quest
 caltransql/
 ├── .env.example                # Connection settings template
 ├── schemas/                    # Table definitions
+│   ├── 00-postgis.sql
 │   ├── 01-bridges.sql
 │   ├── 02-construction-projects.sql
 │   ├── 03-contracts.sql
@@ -193,7 +198,8 @@ caltransql/
 │   ├── 05-subqueries/
 │   ├── 06-window-functions/
 │   ├── 07-ctes/
-│   └── 08-practice-projects/
+│   ├── 08-practice-projects/
+│   └── 09-spatial-postgis/
 ├── data/                       # Downloaded CSV files (git-ignored)
 └── scripts/
     ├── setup-database.sh       # Create database and tables

--- a/exercises/09-spatial-postgis/01-postgis-spatial-analysis-answers.sql
+++ b/exercises/09-spatial-postgis/01-postgis-spatial-analysis-answers.sql
@@ -1,0 +1,189 @@
+-- Answer Key for Exercise 9.1: Spatial Analysis with PostGIS
+
+-- Q1
+WITH params AS (
+    SELECT
+        38.5816::DECIMAL AS input_latitude,
+        -121.4944::DECIMAL AS input_longitude,
+        15::DECIMAL AS radius_km
+),
+bridge_points AS (
+    SELECT
+        structure_number,
+        county,
+        facility_carried,
+        ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography AS geog
+    FROM bridges
+    WHERE latitude IS NOT NULL
+      AND longitude IS NOT NULL
+)
+SELECT
+    b.structure_number,
+    b.county,
+    b.facility_carried,
+    ROUND(
+        ST_Distance(
+            b.geog,
+            ST_SetSRID(ST_MakePoint(p.input_longitude, p.input_latitude), 4326)::geography
+        ) / 1000.0,
+        2
+    ) AS distance_km
+FROM bridge_points b
+CROSS JOIN params p
+WHERE ST_DWithin(
+    b.geog,
+    ST_SetSRID(ST_MakePoint(p.input_longitude, p.input_latitude), 4326)::geography,
+    p.radius_km * 1000
+)
+ORDER BY distance_km;
+
+-- Q2
+WITH bridge_points AS (
+    SELECT
+        structure_number,
+        county,
+        deck_condition,
+        ST_Transform(ST_SetSRID(ST_MakePoint(longitude, latitude), 4326), 3310) AS geom_3310
+    FROM bridges
+    WHERE latitude IS NOT NULL
+      AND longitude IS NOT NULL
+),
+clustered AS (
+    SELECT
+        structure_number,
+        county,
+        deck_condition,
+        ST_ClusterDBSCAN(geom_3310, eps := 5000, minpoints := 5) OVER () AS cluster_id
+    FROM bridge_points
+)
+SELECT
+    cluster_id,
+    COUNT(*) AS bridge_count,
+    ROUND(AVG(deck_condition)::NUMERIC, 2) AS avg_deck_condition
+FROM clustered
+WHERE cluster_id IS NOT NULL
+GROUP BY cluster_id
+ORDER BY bridge_count DESC, cluster_id;
+
+-- Q3
+WITH bridge_points AS (
+    SELECT
+        structure_number,
+        facility_carried,
+        ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography AS geog
+    FROM bridges
+    WHERE latitude IS NOT NULL
+      AND longitude IS NOT NULL
+      AND facility_carried IS NOT NULL
+)
+SELECT
+    b.structure_number,
+    b.facility_carried,
+    n.nearest_structure_number,
+    ROUND(n.distance_m / 1000.0, 2) AS nearest_distance_km
+FROM bridge_points b
+CROSS JOIN LATERAL (
+    SELECT
+        b2.structure_number AS nearest_structure_number,
+        ST_Distance(b.geog, b2.geog) AS distance_m
+    FROM bridge_points b2
+    WHERE b2.facility_carried = b.facility_carried
+      AND b2.structure_number <> b.structure_number
+    ORDER BY ST_Distance(b.geog, b2.geog)
+    LIMIT 1
+) n
+ORDER BY nearest_distance_km
+LIMIT 50;
+
+-- Q4
+WITH bridge_points AS (
+    SELECT
+        structure_number,
+        county,
+        facility_carried,
+        ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography AS geog
+    FROM bridges
+    WHERE latitude IS NOT NULL
+      AND longitude IS NOT NULL
+),
+crash_points AS (
+    SELECT
+        case_id,
+        collision_severity,
+        COALESCE(num_killed, 0) AS num_killed,
+        COALESCE(num_injured, 0) AS num_injured,
+        ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography AS geog
+    FROM crashes
+    WHERE latitude IS NOT NULL
+      AND longitude IS NOT NULL
+),
+nearby_crashes AS (
+    SELECT
+        b.structure_number,
+        b.county,
+        b.facility_carried,
+        c.case_id,
+        c.collision_severity,
+        c.num_killed,
+        c.num_injured
+    FROM bridge_points b
+    JOIN crash_points c
+        ON ST_DWithin(b.geog, c.geog, 1000)
+)
+SELECT
+    structure_number,
+    county,
+    facility_carried,
+    COUNT(DISTINCT case_id) AS nearby_crash_count,
+    COUNT(
+        DISTINCT CASE
+            WHEN collision_severity ILIKE '%fatal%' THEN case_id
+            ELSE NULL
+        END
+    ) AS nearby_fatal_crash_count,
+    SUM(num_killed) AS nearby_killed,
+    SUM(num_injured) AS nearby_injured
+FROM nearby_crashes
+GROUP BY structure_number, county, facility_carried
+ORDER BY nearby_fatal_crash_count DESC, nearby_crash_count DESC
+LIMIT 25;
+
+-- Q5
+WITH project_points AS (
+    SELECT
+        project_id,
+        county,
+        route,
+        ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography AS geog
+    FROM construction_projects
+    WHERE latitude IS NOT NULL
+      AND longitude IS NOT NULL
+),
+station_points AS (
+    SELECT
+        station_id,
+        route,
+        ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography AS geog
+    FROM traffic_counts
+    WHERE latitude IS NOT NULL
+      AND longitude IS NOT NULL
+)
+SELECT
+    p.project_id,
+    p.county,
+    p.route,
+    n.nearest_station_id,
+    n.nearest_station_route,
+    ROUND(n.distance_m / 1000.0, 2) AS nearest_station_distance_km
+FROM project_points p
+CROSS JOIN LATERAL (
+    SELECT
+        s.station_id AS nearest_station_id,
+        s.route AS nearest_station_route,
+        ST_Distance(p.geog, s.geog) AS distance_m
+    FROM station_points s
+    ORDER BY ST_Distance(p.geog, s.geog)
+    LIMIT 1
+) n
+ORDER BY nearest_station_distance_km
+LIMIT 100;

--- a/exercises/09-spatial-postgis/01-postgis-spatial-analysis-hints.sql
+++ b/exercises/09-spatial-postgis/01-postgis-spatial-analysis-hints.sql
@@ -1,0 +1,21 @@
+-- Hints for Exercise 9.1: Spatial Analysis with PostGIS
+
+-- Q1 hint:
+-- Build params once, then CROSS JOIN it to your bridge points.
+-- Convert radius_km to meters by multiplying by 1000.
+
+-- Q2 hint:
+-- ST_ClusterDBSCAN runs as a window function.
+-- Use ST_Transform(..., 3310) so eps=5000 means 5 km.
+
+-- Q3 hint:
+-- Use CROSS JOIN LATERAL to find one nearest neighbor per bridge
+-- after filtering candidates to the same facility_carried.
+
+-- Q4 hint:
+-- Build bridge_points and crash_points CTEs first, then ST_DWithin
+-- at 1000 meters. Aggregate by bridge structure_number.
+
+-- Q5 hint:
+-- Similar to Q3, but project_points -> station_points using a
+-- lateral subquery ordered by ST_Distance(...).

--- a/exercises/09-spatial-postgis/01-postgis-spatial-analysis.sql
+++ b/exercises/09-spatial-postgis/01-postgis-spatial-analysis.sql
@@ -1,0 +1,112 @@
+-- ============================================================
+-- Exercise 9.1: Spatial Analysis with PostGIS
+-- ============================================================
+-- Goal:
+-- Practice real GIS workflows with transportation data that already
+-- includes latitude/longitude columns.
+--
+-- Tables used:
+--   bridges
+--   traffic_counts
+--   crashes
+--   construction_projects
+--
+-- Important:
+-- 1) These exercises require PostGIS.
+-- 2) Distances are measured in meters when you cast to geography.
+-- ============================================================
+
+-- Optional check:
+-- SELECT PostGIS_Version();
+
+
+-- ----- EXAMPLE -----
+-- Find bridges within 10 km of downtown Sacramento.
+
+WITH params AS (
+    SELECT ST_SetSRID(ST_MakePoint(-121.4944, 38.5816), 4326)::geography AS center_geog
+),
+bridge_points AS (
+    SELECT
+        structure_number,
+        county,
+        facility_carried,
+        ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography AS geog
+    FROM bridges
+    WHERE latitude IS NOT NULL
+      AND longitude IS NOT NULL
+)
+SELECT
+    b.structure_number,
+    b.county,
+    b.facility_carried,
+    ROUND(ST_Distance(b.geog, p.center_geog) / 1000.0, 2) AS distance_km
+FROM bridge_points b
+CROSS JOIN params p
+WHERE ST_DWithin(b.geog, p.center_geog, 10000)
+ORDER BY distance_km
+LIMIT 25;
+
+
+-- ----- YOUR TURN -----
+
+-- Q1: Parameterize the "bridges within X km" query.
+--     Create a params CTE with:
+--       input_latitude, input_longitude, radius_km
+--     Return all bridges within radius_km of that point.
+--     Include distance_km and sort nearest first.
+
+
+-- Q2: Cluster bridges by geographic proximity.
+--     Use ST_ClusterDBSCAN with:
+--       eps = 5000 meters
+--       minpoints = 5
+--     Return one row per cluster with:
+--       cluster_id, bridge_count, avg_deck_condition
+--
+--     Hint: transform to EPSG:3310 before clustering so units are meters.
+
+
+-- Q3: For each bridge, find the nearest other bridge on the same
+--     facility_carried route.
+--     Return:
+--       structure_number
+--       facility_carried
+--       nearest_structure_number
+--       nearest_distance_km
+--     Limit to 50 rows.
+
+
+-- Q4: Spatial join crashes near bridges.
+--     Count crashes within 1 km of each bridge and include:
+--       nearby_crash_count
+--       nearby_fatal_crash_count
+--       nearby_killed
+--       nearby_injured
+--     Return the top 25 bridges by nearby_fatal_crash_count.
+
+
+-- Q5: Find the nearest traffic station for each construction project.
+--     Return:
+--       project_id
+--       county
+--       route
+--       nearest_station_id
+--       nearest_station_route
+--       nearest_station_distance_km
+--     Limit to 100 rows.
+
+
+-- ============================================================
+-- Stretch Goals
+-- ============================================================
+
+-- Stretch 1:
+-- Build a county-level "spatial risk" table by combining:
+--   - poor bridge counts (deck_condition <= 4)
+--   - crashes within 1 km of bridges
+--   - average distance from projects to nearest traffic station
+
+-- Stretch 2:
+-- Create a simple heatmap grid with ST_SnapToGrid over bridge points.
+-- Summarize bridge counts and average condition by grid cell.

--- a/schemas/00-postgis.sql
+++ b/schemas/00-postgis.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- PostGIS extension bootstrap (optional but recommended)
+-- ============================================================
+-- This script tries to enable PostGIS so spatial/GIS exercises
+-- can use ST_DWithin, ST_Distance, clustering, and spatial joins.
+--
+-- If PostGIS is not installed on the PostgreSQL server, or if the
+-- current user cannot CREATE EXTENSION, setup will continue and
+-- print a warning instead of hard failing.
+-- ============================================================
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_available_extensions
+        WHERE name = 'postgis'
+    ) THEN
+        BEGIN
+            CREATE EXTENSION IF NOT EXISTS postgis;
+            RAISE NOTICE 'PostGIS extension is enabled for this database.';
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RAISE WARNING 'PostGIS is available but could not be enabled: insufficient privilege for CREATE EXTENSION.';
+                RAISE WARNING 'Ask your database admin to run: CREATE EXTENSION postgis;';
+        END;
+    ELSE
+        RAISE WARNING 'PostGIS extension is not installed on this PostgreSQL server.';
+        RAISE WARNING 'Install PostGIS packages on the server to use spatial exercises.';
+    END IF;
+END
+$$;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `schemas/00-postgis.sql` to bootstrap PostGIS during setup (with safe warnings when unavailable or lacking privileges)
- add a new advanced module at `exercises/09-spatial-postgis/` with guided prompts, hints, and sample answers
- update `README.md` to document PostGIS prerequisites, setup behavior, and the new module in the exercises and project structure lists

## Validation
- Structural/content review of new SQL files and README updates
- Functional query execution pending environment-specific PostgreSQL/PostGIS connection details
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DAT-3](https://linear.app/alecv/issue/DAT-3/explore-adding-spatialgis-queries-with-postgis)

<div><a href="https://cursor.com/agents/bc-ced64c10-347f-4d4d-9fff-3bd527cbc5f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ced64c10-347f-4d4d-9fff-3bd527cbc5f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

