### PR TITLE
Add optional Docker Compose setup for local PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,16 @@
+# Primary/recommended setup: existing PostgreSQL server
 PGHOST=192.168.4.181
 PGPORT=5433
 PGUSER=alec
 PGPASSWORD=
 PGDATABASE=caltransql
+# Optional: database used for admin commands (CREATE DATABASE, etc.)
+# PGMAINTENANCE_DB=postgres
+
+# If using docker/docker-compose.yml, use:
+# PGHOST=localhost
+# PGPORT=5433
+# PGUSER=caltrans
+# PGPASSWORD=caltrans
+# PGDATABASE=caltransql
+# PGMAINTENANCE_DB=postgres

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CaltransSQL
 
-A hands-on SQL practice environment using real California transportation data. Uses a remote PostgreSQL server with JetBrains DataGrip as the query editor.
+A hands-on SQL practice environment using real California transportation data. The primary/recommended workflow uses an existing PostgreSQL server with JetBrains DataGrip as the query editor.
 
 ## Prerequisites
 
@@ -8,6 +8,7 @@ A hands-on SQL practice environment using real California transportation data. U
 - **JetBrains DataGrip** (or any SQL client)
 - **psql CLI** for running setup scripts (`brew install libpq` on macOS, then add to PATH)
 - **PostGIS extension available on your server** (required for the optional spatial module in `exercises/09-spatial-postgis/`)
+- **Docker + Docker Compose** (optional fallback if you do not have PostgreSQL)
 
 ## Quick Start
 
@@ -28,6 +29,45 @@ cp .env.example .env
 
 # 5. Validate the loaded data
 ./scripts/validate-data.sh
+```
+
+## Don't have PostgreSQL? Use Docker (optional)
+
+The direct PostgreSQL setup above is still the default path. If you do not already have a PostgreSQL server, you can run one locally with Docker Compose.
+
+```bash
+# 1. Copy env file
+cp .env.example .env
+
+# 2. In .env, set local Docker values:
+#    PGHOST=localhost
+#    PGPORT=5433
+#    PGUSER=caltrans
+#    PGPASSWORD=caltrans
+#    PGDATABASE=caltransql
+#    PGMAINTENANCE_DB=postgres
+
+# 3. Start PostgreSQL only
+docker compose -f docker/docker-compose.yml up -d postgres
+
+# Optional: also start pgAdmin + NocoDB
+docker compose -f docker/docker-compose.yml --profile tools up -d
+
+# 4. Run normal setup/load scripts
+./scripts/setup-database.sh
+./scripts/download-data.sh
+./scripts/load-data.sh
+./scripts/validate-data.sh
+```
+
+Optional services when `--profile tools` is enabled:
+- **pgAdmin:** http://localhost:5050 (defaults in compose file)
+- **NocoDB:** http://localhost:8080
+
+Stop services with:
+
+```bash
+docker compose -f docker/docker-compose.yml down
 ```
 
 ## Connecting DataGrip
@@ -180,6 +220,8 @@ Work through the exercises in order. Each file has examples to study, then quest
 ```
 caltransql/
 ├── .env.example                # Connection settings template
+├── docker/
+│   └── docker-compose.yml      # Optional local PostgreSQL + tools
 ├── schemas/                    # Table definitions
 │   ├── 00-postgis.sql
 │   ├── 01-bridges.sql

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  postgres:
+    image: postgres:17
+    container_name: caltransql-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-caltrans}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-caltrans}
+      POSTGRES_DB: ${POSTGRES_DB:-caltransql}
+    ports:
+      - "${POSTGRES_PORT:-5433}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-caltrans} -d ${POSTGRES_DB:-caltransql}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: caltransql-pgadmin
+    restart: unless-stopped
+    profiles: ["tools"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@example.com}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
+      PGADMIN_LISTEN_PORT: 80
+    ports:
+      - "${PGADMIN_PORT:-5050}:80"
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+
+  nocodb:
+    image: nocodb/nocodb:latest
+    container_name: caltransql-nocodb
+    restart: unless-stopped
+    profiles: ["tools"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      NC_DB: "pg://postgres:5432?u=${POSTGRES_USER:-caltrans}&p=${POSTGRES_PASSWORD:-caltrans}&d=${POSTGRES_DB:-caltransql}"
+    ports:
+      - "${NOCO_PORT:-8080}:8080"
+    volumes:
+      - nocodb_data:/usr/app/data
+
+volumes:
+  postgres_data:
+  pgadmin_data:
+  nocodb_data:

--- a/scripts/setup-database.sh
+++ b/scripts/setup-database.sh
@@ -28,8 +28,29 @@ else
     exit 1
 fi
 
+# Maintenance database used for admin commands such as CREATE DATABASE.
+# Can be overridden in .env with PGMAINTENANCE_DB.
+if [ -n "${PGMAINTENANCE_DB:-}" ]; then
+    MAINTENANCE_DB="$PGMAINTENANCE_DB"
+else
+    MAINTENANCE_DB=""
+    for candidate_db in postgres personal template1; do
+        if psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$candidate_db" -c "SELECT 1;" &>/dev/null; then
+            MAINTENANCE_DB="$candidate_db"
+            break
+        fi
+    done
+fi
+
+if [ -z "$MAINTENANCE_DB" ]; then
+    echo "ERROR: Cannot connect to any maintenance database (tried: postgres, personal, template1)."
+    echo "Set PGMAINTENANCE_DB in .env if your server uses a different admin database."
+    exit 1
+fi
+
 echo "=== CaltransSQL Database Setup ==="
 echo "Server: $PGHOST:$PGPORT"
+echo "Maintenance DB: $MAINTENANCE_DB"
 echo ""
 
 # Check psql is available
@@ -38,8 +59,8 @@ if ! command -v psql &>/dev/null; then
     exit 1
 fi
 
-# Check connectivity (connect to the existing database to run admin commands)
-if ! psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d personal -c "SELECT 1;" &>/dev/null; then
+# Check connectivity (connect to the existing maintenance database to run admin commands)
+if ! psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$MAINTENANCE_DB" -c "SELECT 1;" &>/dev/null; then
     echo "ERROR: Cannot connect to PostgreSQL at $PGHOST:$PGPORT"
     echo "Check your .env settings and that the server is running."
     exit 1
@@ -47,10 +68,15 @@ fi
 
 # Create the caltransql database if it doesn't exist
 echo "Creating database '$PGDATABASE' (if it doesn't exist)..."
-psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d personal -tc \
-    "SELECT 1 FROM pg_database WHERE datname = '$PGDATABASE';" | grep -q 1 \
-    || psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d personal -c \
-    "CREATE DATABASE $PGDATABASE;"
+DB_EXISTS=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$MAINTENANCE_DB" \
+    -v ON_ERROR_STOP=1 -v target_db="$PGDATABASE" -tAc \
+    "SELECT 1 FROM pg_database WHERE datname = :'target_db';")
+
+if [ "$DB_EXISTS" != "1" ]; then
+    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$MAINTENANCE_DB" \
+        -v ON_ERROR_STOP=1 -v target_db="$PGDATABASE" -c \
+        "SELECT format('CREATE DATABASE %I', :'target_db') \gexec"
+fi
 
 echo "Database '$PGDATABASE' ready."
 echo ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `docker/docker-compose.yml` with a default PostgreSQL service for users who do not have an existing server
- include optional `pgAdmin` and `NocoDB` services behind the `tools` compose profile
- add a README section: **"Don't have PostgreSQL? Use Docker (optional)"** with startup/shutdown commands and `.env` guidance
- update `.env.example` with optional Docker connection values and `PGMAINTENANCE_DB` notes
- make `scripts/setup-database.sh` portable by replacing the hardcoded `personal` admin DB with auto-detection (`postgres`, `personal`, `template1`) plus explicit override via `PGMAINTENANCE_DB`

## Testing
- `bash -n scripts/setup-database.sh`
- `docker compose -f docker/docker-compose.yml config` *(not runnable in this cloud environment: `docker: command not found`)*
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DAT-5](https://linear.app/alecv/issue/DAT-5/add-optional-docker-compose-for-portable-setup)

<div><a href="https://cursor.com/agents/bc-7561ec47-bc55-491a-b44a-a596c7f0fad4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7561ec47-bc55-491a-b44a-a596c7f0fad4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

