### PR TITLE
Add recursive CTE capstone exercise to module 07

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Work through the exercises in order. Each file has examples to study, then quest
 | 04b | UNION, INTERSECT, EXCEPT, and self-joins | `exercises/04b-set-operations/` | Intermediate |
 | 05  | Subqueries, EXISTS, NOT EXISTS | `exercises/05-subqueries/` | Intermediate |
 | 06  | Window Functions, running totals, percentiles | `exercises/06-window-functions/` | Intermediate/Advanced |
-| 07  | CTEs and multi-step analysis | `exercises/07-ctes/`    | Intermediate/Advanced |
+| 07  | CTEs, recursive CTEs, and multi-step analysis | `exercises/07-ctes/`    | Intermediate/Advanced |
 | 08  | Practice Projects   | `exercises/08-practice-projects/` | All levels  |
 | 09  | Spatial analysis with PostGIS | `exercises/09-spatial-postgis/` | Advanced |
 
@@ -138,6 +138,7 @@ Work through the exercises in order. Each file has examples to study, then quest
 - `exercises/05-subqueries/02-exists-and-not-exists.sql`
 - `exercises/06-window-functions/02-running-stats-and-percentiles.sql`
 - `exercises/07-ctes/02-multi-step-analysis.sql`
+- `exercises/07-ctes/03-recursive.sql`
 - `exercises/09-spatial-postgis/01-postgis-spatial-analysis.sql`
 
 ### Expanded Practice Projects

--- a/exercises/07-ctes/03-recursive-answers.sql
+++ b/exercises/07-ctes/03-recursive-answers.sql
@@ -1,0 +1,243 @@
+-- Answer Key for Exercise 7.3: Recursive CTEs (WITH RECURSIVE)
+
+-- Q1
+WITH RECURSIVE route_candidates AS (
+    SELECT county, route, COUNT(*) AS segment_count
+    FROM construction_projects
+    WHERE route IS NOT NULL
+      AND county IS NOT NULL
+      AND post_mile_start IS NOT NULL
+    GROUP BY county, route
+    ORDER BY segment_count DESC
+    LIMIT 1
+),
+ordered_projects AS (
+    SELECT
+        p.project_id,
+        p.county,
+        p.route,
+        p.post_mile_start,
+        p.post_mile_end,
+        p.total_cost
+    FROM construction_projects p
+    JOIN route_candidates rc
+      ON p.county = rc.county
+     AND p.route = rc.route
+    WHERE p.post_mile_start IS NOT NULL
+),
+route_seed AS (
+    SELECT
+        op.project_id,
+        op.county,
+        op.route,
+        op.post_mile_start,
+        op.post_mile_end,
+        op.total_cost
+    FROM ordered_projects op
+    ORDER BY op.post_mile_start
+    LIMIT 1
+),
+route_walk AS (
+    SELECT
+        rs.project_id,
+        rs.county,
+        rs.route,
+        rs.post_mile_start,
+        rs.post_mile_end,
+        rs.total_cost,
+        1 AS step_no,
+        ARRAY[rs.project_id] AS visited_projects
+    FROM route_seed rs
+
+    UNION ALL
+
+    SELECT
+        next_op.project_id,
+        next_op.county,
+        next_op.route,
+        next_op.post_mile_start,
+        next_op.post_mile_end,
+        next_op.total_cost,
+        rw.step_no + 1,
+        rw.visited_projects || next_op.project_id
+    FROM route_walk rw
+    JOIN LATERAL (
+        SELECT op.*
+        FROM ordered_projects op
+        WHERE op.post_mile_start > COALESCE(rw.post_mile_end, rw.post_mile_start)
+          AND NOT (op.project_id = ANY (rw.visited_projects))
+        ORDER BY op.post_mile_start
+        LIMIT 1
+    ) next_op ON TRUE
+    WHERE rw.step_no < 15
+)
+SELECT
+    step_no,
+    county,
+    route,
+    project_id,
+    post_mile_start,
+    post_mile_end,
+    total_cost
+FROM route_walk
+ORDER BY step_no;
+
+-- Q2
+WITH RECURSIVE month_bounds AS (
+    SELECT
+        DATE_TRUNC('month', MIN(start_date))::date AS min_month,
+        DATE_TRUNC('month', MAX(start_date))::date AS max_month
+    FROM construction_projects
+    WHERE start_date IS NOT NULL
+),
+month_series AS (
+    SELECT min_month AS month_start
+    FROM month_bounds
+    UNION ALL
+    SELECT (ms.month_start + INTERVAL '1 month')::date
+    FROM month_series ms
+    CROSS JOIN month_bounds b
+    WHERE ms.month_start < b.max_month
+),
+monthly_projects AS (
+    SELECT
+        DATE_TRUNC('month', start_date)::date AS month_start,
+        COUNT(*) AS project_count,
+        SUM(total_cost) AS total_project_cost
+    FROM construction_projects
+    WHERE start_date IS NOT NULL
+    GROUP BY 1
+)
+SELECT
+    ms.month_start,
+    COALESCE(mp.project_count, 0) AS project_count,
+    COALESCE(mp.total_project_cost, 0) AS total_project_cost
+FROM month_series ms
+LEFT JOIN monthly_projects mp
+  ON ms.month_start = mp.month_start
+ORDER BY ms.month_start;
+
+-- Q3
+WITH RECURSIVE phase_base AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY approval_date, project_id) AS phase_no,
+        project_id,
+        total_cost AS phase_cost
+    FROM construction_projects
+    WHERE approval_date IS NOT NULL
+      AND total_cost IS NOT NULL
+),
+phase_rollup AS (
+    SELECT
+        pb.phase_no,
+        pb.project_id,
+        pb.phase_cost,
+        pb.phase_cost AS cumulative_phase_cost
+    FROM phase_base pb
+    WHERE pb.phase_no = 1
+
+    UNION ALL
+
+    SELECT
+        next_phase.phase_no,
+        next_phase.project_id,
+        next_phase.phase_cost,
+        pr.cumulative_phase_cost + next_phase.phase_cost AS cumulative_phase_cost
+    FROM phase_rollup pr
+    JOIN phase_base next_phase
+      ON next_phase.phase_no = pr.phase_no + 1
+)
+SELECT
+    phase_no,
+    project_id,
+    phase_cost,
+    cumulative_phase_cost
+FROM phase_rollup
+ORDER BY phase_no
+LIMIT 25;
+
+-- Q4
+WITH RECURSIVE route_candidates AS (
+    SELECT county, route, COUNT(*) AS segment_count
+    FROM construction_projects
+    WHERE route IS NOT NULL
+      AND county IS NOT NULL
+      AND post_mile_start IS NOT NULL
+    GROUP BY county, route
+    ORDER BY segment_count DESC
+    LIMIT 1
+),
+ordered_projects AS (
+    SELECT
+        p.project_id,
+        p.county,
+        p.route,
+        p.post_mile_start,
+        p.post_mile_end,
+        COALESCE(p.total_cost, 0) AS segment_cost
+    FROM construction_projects p
+    JOIN route_candidates rc
+      ON p.county = rc.county
+     AND p.route = rc.route
+    WHERE p.post_mile_start IS NOT NULL
+),
+route_budget_seed AS (
+    SELECT
+        op.project_id,
+        op.county,
+        op.route,
+        op.post_mile_start,
+        op.post_mile_end,
+        op.segment_cost
+    FROM ordered_projects op
+    ORDER BY op.post_mile_start
+    LIMIT 1
+),
+route_budget_walk AS (
+    SELECT
+        rbs.project_id,
+        rbs.county,
+        rbs.route,
+        rbs.post_mile_start,
+        rbs.post_mile_end,
+        rbs.segment_cost,
+        rbs.segment_cost AS running_total_cost,
+        1 AS step_no,
+        ARRAY[rbs.project_id] AS visited_projects
+    FROM route_budget_seed rbs
+
+    UNION ALL
+
+    SELECT
+        next_op.project_id,
+        next_op.county,
+        next_op.route,
+        next_op.post_mile_start,
+        next_op.post_mile_end,
+        next_op.segment_cost,
+        rbw.running_total_cost + next_op.segment_cost AS running_total_cost,
+        rbw.step_no + 1 AS step_no,
+        rbw.visited_projects || next_op.project_id AS visited_projects
+    FROM route_budget_walk rbw
+    JOIN LATERAL (
+        SELECT op.*
+        FROM ordered_projects op
+        WHERE op.post_mile_start > COALESCE(rbw.post_mile_end, rbw.post_mile_start)
+          AND NOT (op.project_id = ANY (rbw.visited_projects))
+        ORDER BY op.post_mile_start
+        LIMIT 1
+    ) next_op ON TRUE
+    WHERE rbw.step_no < 12
+      AND rbw.running_total_cost <= 250000000
+)
+SELECT
+    step_no,
+    county,
+    route,
+    project_id,
+    post_mile_start,
+    post_mile_end,
+    segment_cost,
+    running_total_cost
+FROM route_budget_walk
+ORDER BY step_no;

--- a/exercises/07-ctes/03-recursive-hints.sql
+++ b/exercises/07-ctes/03-recursive-hints.sql
@@ -1,0 +1,17 @@
+-- Hints for Exercise 7.3: Recursive CTEs (WITH RECURSIVE)
+
+-- Q1 hint:
+-- Use an anchor row (smallest post_mile_start), then recurse to the next
+-- row with a larger post_mile_start. A visited array helps prevent loops.
+
+-- Q2 hint:
+-- Build month_bounds first, then recurse month by month until max_month.
+-- Left join aggregated monthly project counts.
+
+-- Q3 hint:
+-- Create phase_base with ROW_NUMBER(), anchor on phase_no = 1,
+-- then join to phase_no + 1 in the recursive term.
+
+-- Q4 hint:
+-- Add running_total_cost to the recursive CTE output and keep recursing
+-- only while step_no < 12 and running_total_cost <= 250000000.

--- a/exercises/07-ctes/03-recursive.sql
+++ b/exercises/07-ctes/03-recursive.sql
@@ -1,0 +1,88 @@
+-- ============================================================
+-- Exercise 7.3: Recursive CTEs (WITH RECURSIVE)
+-- ============================================================
+-- Recursive CTEs let a query refer to its own prior output.
+-- They are useful for:
+--   - ordered traversal problems (route/post_mile chains)
+--   - date/quarter series generation for gap filling
+--   - iterative rollups like cumulative budget by phase
+-- ============================================================
+
+
+-- ----- EXAMPLES -----
+
+-- Basic recursion: count from 1 to 5
+WITH RECURSIVE step_counter AS (
+    SELECT 1 AS step_no
+    UNION ALL
+    SELECT step_no + 1
+    FROM step_counter
+    WHERE step_no < 5
+)
+SELECT *
+FROM step_counter;
+
+-- Generate a month series between min and max contract award month
+WITH RECURSIVE month_bounds AS (
+    SELECT
+        DATE_TRUNC('month', MIN(award_date))::date AS min_month,
+        DATE_TRUNC('month', MAX(award_date))::date AS max_month
+    FROM contracts
+    WHERE award_date IS NOT NULL
+),
+month_series AS (
+    SELECT min_month AS month_start
+    FROM month_bounds
+    UNION ALL
+    SELECT (month_start + INTERVAL '1 month')::date
+    FROM month_series ms
+    CROSS JOIN month_bounds b
+    WHERE ms.month_start < b.max_month
+)
+SELECT month_start
+FROM month_series
+ORDER BY month_start
+LIMIT 24;
+
+
+-- ----- YOUR TURN -----
+
+-- Q1: Route traversal by post mile
+--     Build a recursive query that walks project segments in order.
+--     Suggested steps:
+--       1) route_candidates: pick one county+route with post_mile data
+--       2) ordered_projects: all projects for that county+route
+--       3) route_walk (recursive):
+--          - anchor = smallest post_mile_start
+--          - recursive step = next nearest post_mile_start
+--       4) include step_no and a visited_projects array to avoid loops
+--     Return up to 15 steps in traversal order.
+
+
+-- Q2: Date series generation + gap filling
+--     Use WITH RECURSIVE to generate every month between the minimum
+--     and maximum start_date in construction_projects.
+--     Then left join monthly project counts so months with no projects
+--     still appear with 0.
+--     Return: month_start, project_count, total_project_cost.
+
+
+-- Q3: Recursive cumulative phase cost rollup
+--     Create a phase list from construction_projects by ordering rows
+--     with non-null approval_date and total_cost.
+--     Use ROW_NUMBER() as phase_no.
+--     Then build a recursive CTE that accumulates total_cost one phase
+--     at a time.
+--     Return: phase_no, project_id, phase_cost, cumulative_phase_cost.
+
+
+-- ============================================================
+-- Challenge
+-- ============================================================
+
+-- Q4: Budget-capped route walk
+--     Extend Q1 so the recursion stops when either:
+--       - 12 steps have been reached, or
+--       - running_total_cost exceeds 250,000,000
+--     Return step_no, county, route, project_id, post_mile range,
+--     segment_cost, and running_total_cost.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new module 7 exercise file: `exercises/07-ctes/03-recursive.sql`
- add companion hint and answer files for the new recursive CTE content
- cover three applied recursive patterns: route traversal by post mile, date-series generation for gap filling, and cumulative phase cost rollups
- add a challenge prompt for budget-capped recursive traversal
- update README module wording and recently-added list to include the new recursive exercise

## Validation
- reviewed SQL structure and fixed recursive answer seeds so PostgreSQL set-operation syntax remains valid (`ORDER BY/LIMIT` moved into seed CTEs)
- no automated SQL test harness is configured in this repo for exercise files
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DAT-4](https://linear.app/alecv/issue/DAT-4/add-recursive-ctes-exercise)

<div><a href="https://cursor.com/agents/bc-110e3ec5-cd35-45f1-9486-ddaeab96d1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-110e3ec5-cd35-45f1-9486-ddaeab96d1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

